### PR TITLE
Change force:auth to auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function createAuthFile(){
 
 function authSFDX(){
   var params = '--setdefaultdevhubusername --setdefaultusername -a SFDX-ENV'
-  exec('sfdx force:auth:sfdxurl:store -f /tmp/sfdx_auth.txt '+params, function(error, stdout, stderr){
+  exec('sfdx auth:sfdxurl:store -f /tmp/sfdx_auth.txt '+params, function(error, stdout, stderr){
     if(error) throw(stderr)
 	core.debug(stdout)
   })


### PR DESCRIPTION
Since sfdx v50.0, [force:auth commands are moved](https://github.com/forcedotcom/cli/blob/main/releasenotes/README.md#5020-october-22-2020---cli-7771) to their own namespace.
There are some [issues](https://github.com/forcedotcom/cli/issues/787) to use force:auth, and they are appearently affecting this action.

With current set-up, the action exits with error code:

```
/home/runner/work/_actions/sfdx-actions/setup-sfdx/v1/index.js:32
    if(error) throw(stderr)
              ^
 ›   Warning: force:auth:sfdxurl:store is not a sfdx command.
Did you mean auth:sfdxurl:store? [y/n]:  ›   Error: Run sfdx help force for a list of available commands.
```

Auth namespace should be used from now on instead of force:auth.