### PR TITLE
Allow override of URL to download SFDX CLI tarball

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   sfdx-auth-url:
     description: Authorize a Salesforce org using an SFDX auth URL
     required: false
+  tarball-url:
+    description: Supply a URL to a XZip'd tarball containing the version of the SFDX CLI to install. If omitted or blank, it will install the "latest" CLI
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -9,12 +9,12 @@ try {
 }
 
 function installSFDX(){
-  var download = 'wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz -P /tmp'
+  var download = 'wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz -P /tmp'
   var createDir = 'mkdir sfdx'
   var unzip = 'tar xJf /tmp/sfdx-linux-amd64.tar.xz -C sfdx --strip-components 1'
-  var install = './sfdx/install'
-  var clean = 'rm -r ./sfdx'
-  exec(download+' && '+createDir+' && '+unzip+' && '+install+' && '+clean, function(error, stdout, stderr){
+  var install = 'echo "`pwd`/sfdx/bin" >> $GITHUB_PATH'
+  var version = 'sfdx/bin/sfdx --version'
+  exec(download+' && '+createDir+' && '+unzip+' && '+install+' && '+version, function(error, stdout, stderr){
     if(error) throw(stderr)
     core.debug(stdout)
     if(core.getInput('sfdx-auth-url')) createAuthFile()
@@ -27,8 +27,8 @@ function createAuthFile(){
 }
 
 function authSFDX(){
-  var params = '--setdefaultdevhubusername --setdefaultusername -a SFDX-ENV'
-  exec('sfdx auth:sfdxurl:store -f /tmp/sfdx_auth.txt '+params, function(error, stdout, stderr){
+  var params = '--setdefaultdevhubusername -a SFDX-ENV'
+  exec('sfdx/bin/sfdx auth:sfdxurl:store -f /tmp/sfdx_auth.txt '+params, function(error, stdout, stderr){
     if(error) throw(stderr)
 	core.debug(stdout)
   })

--- a/index.js
+++ b/index.js
@@ -9,9 +9,18 @@ try {
 }
 
 function installSFDX(){
-  var download = 'wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz -q -P /tmp'
+  var tarballBase = 'https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable'
+  var tarballFile = 'sfdx-linux-x64.tar.xz'
+
+  var tarballOverride = core.getInput('tarball-url')
+  if(tarballOverride ){
+    tarballBase = tarballOverride.substr(0,tarballOverride.lastIndexOf('/'))
+    tarballFile = tarballOverride.substr(tarballOverride.lastIndexOf('/')+1)
+  }
+
+  var download = 'wget ' + tarballBase + '/' + tarballFile + ' -q -P /tmp'
   var createDir = 'mkdir sfdx'
-  var unzip = 'tar xJf /tmp/sfdx-linux-x64.tar.xz -C sfdx --strip-components 1'
+  var unzip = 'tar xJf /tmp/' + tarballFile + ' -C sfdx --strip-components 1'
   var install = 'echo "`pwd`/sfdx/bin" >> $GITHUB_PATH'
   var version = 'sfdx/bin/sfdx --version && sfdx/bin/sfdx plugins --core'
   exec(download+' && '+createDir+' && '+unzip+' && '+install+' && '+version, function(error, stdout, stderr){

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function createAuthFile(){
 }
 
 function authSFDX(){
-  var params = '--setdefaultdevhubusername -a SFDX-ENV'
+  var params = '--setdefaultdevhubusername --setdefaultusername -a SFDX-ENV'
   exec('sfdx/bin/sfdx auth:sfdxurl:store -f /tmp/sfdx_auth.txt '+params, function(error, stdout, stderr){
     if(error) throw(stderr)
 	core.debug(stdout)

--- a/index.js
+++ b/index.js
@@ -9,14 +9,14 @@ try {
 }
 
 function installSFDX(){
-  var download = 'wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz -P /tmp'
+  var download = 'wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz -q -P /tmp'
   var createDir = 'mkdir sfdx'
   var unzip = 'tar xJf /tmp/sfdx-linux-x64.tar.xz -C sfdx --strip-components 1'
   var install = 'echo "`pwd`/sfdx/bin" >> $GITHUB_PATH'
-  var version = 'sfdx/bin/sfdx --version'
+  var version = 'sfdx/bin/sfdx --version && sfdx/bin/sfdx plugins --core'
   exec(download+' && '+createDir+' && '+unzip+' && '+install+' && '+version, function(error, stdout, stderr){
     if(error) throw(stderr)
-    core.debug(stdout)
+    core.info(stdout)
     if(core.getInput('sfdx-auth-url')) createAuthFile()
   })
 }
@@ -30,7 +30,7 @@ function authSFDX(){
   var params = '--setdefaultdevhubusername --setdefaultusername -a SFDX-ENV'
   exec('sfdx/bin/sfdx auth:sfdxurl:store -f /tmp/sfdx_auth.txt '+params, function(error, stdout, stderr){
     if(error) throw(stderr)
-	core.debug(stdout)
+	core.info(stdout)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ try {
 function installSFDX(){
   var download = 'wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz -P /tmp'
   var createDir = 'mkdir sfdx'
-  var unzip = 'tar xJf /tmp/sfdx-linux-amd64.tar.xz -C sfdx --strip-components 1'
+  var unzip = 'tar xJf /tmp/sfdx-linux-x64.tar.xz -C sfdx --strip-components 1'
   var install = 'echo "`pwd`/sfdx/bin" >> $GITHUB_PATH'
   var version = 'sfdx/bin/sfdx --version'
   exec(download+' && '+createDir+' && '+unzip+' && '+install+' && '+version, function(error, stdout, stderr){


### PR DESCRIPTION
We have gotten burned a few times by always running the 'latest' SFDX CLI in our CI workflow. The most recent example of this was over here:

 https://github.com/forcedotcom/cli/issues/1165

This pull request adds a new input for the Action so that the URL to the tarball can be overridden in the workflow file to pin your workflow to a stable version of the CLI

This PR builds upon my other PR that still is awaiting merge (https://github.com/sfdx-actions/setup-sfdx/pull/8)